### PR TITLE
Multiple hover types

### DIFF
--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -18,12 +18,24 @@ a:hover {
 }
 
 // Mixin for adjusting brightness of an element on hover
-@mixin basic-hover() {
+@mixin basic-hover($type) {
     cursor: pointer;
     
     // SASS parent selector! (&)
     &:hover {
-        filter: brightness(80%);
+        // Default light hover preset
+        @if $type == light {
+            filter: brightness(120%);
+        } 
+        // Default dark hover preset
+        @else if $type == dark {
+            filter: brightness(80%);
+        }
+        // For custom brightnesses
+        @else {
+            filter: brightness($type)
+        };
+
         transition: filter .2s;
     }
 

--- a/_sass/minima/pages/nav.scss
+++ b/_sass/minima/pages/nav.scss
@@ -18,7 +18,7 @@
         z-index: 1;
 
         .nav-title {
-            @include basic-hover();
+            @include basic-hover(dark);
             
             font-family: $nighthawk-font2;
             color: white;
@@ -38,7 +38,7 @@
             margin-right: 0;
 
             img {
-                @include basic-hover();
+                @include basic-hover(dark);
 
                 height: 3vw;
                 width: 3vw;
@@ -87,7 +87,7 @@
         top: calc(30vw/6);
 
         .nav-button {
-            @include basic-hover();
+            @include basic-hover(dark);
 
             font-family: $nighthawk-font2;
             color: white;
@@ -109,7 +109,7 @@
 }
 
 .nav-logo {
-    @include basic-hover();
+    @include basic-hover(dark);
 
     background-color: $nighthawk-green;
     border-radius: 50%;


### PR DESCRIPTION
## Hover Mixin Change:
Added a parameter to the SCSS "basic-hover" mixin, that allows us to use default values for darkening or lightening on hover, or inputting a custom value.

![Screen Shot 2024-02-07 at 2 52 47 PM](https://github.com/John-sCC/jcc_frontend/assets/112529809/91407a92-81d6-4d5d-ab36-460ffa7b654c)

### Usage example:

![Screen Shot 2024-02-07 at 2 53 23 PM](https://github.com/John-sCC/jcc_frontend/assets/112529809/ea5fa860-143f-4443-8eea-2c62fa2bd094)
